### PR TITLE
added ref qualified get members for ul::compressed_pair

### DIFF
--- a/test/compressed_pair.cpp
+++ b/test/compressed_pair.cpp
@@ -4,6 +4,8 @@
 
 #include <catch2/catch.hpp>
 #include <umlaut/compressed_pair.hpp>
+#include <type_traits>
+#include <utility>
 #include <string>
 
 struct empty_cat { std::string purr() const { return "purr"; } };
@@ -15,7 +17,23 @@ TEST_CASE("access functions for compressed_pair", "[compressed_pair]") {
     CHECK(pair.second().purr() == "purr");
 }
 
-TEST_CASE("empty base optimization of compressed_pair", "[compressed_pair]") {
+TEST_CASE("access overload resolution from compressed_pair", "[compressed_pair]") {
+    using T = ul::compressed_pair<int, int>;
+
+    CHECK(std::is_same_v<decltype(std::declval<T&>().first()), int&>);
+    CHECK(std::is_same_v<decltype(std::declval<T&&>().first()), int&&>);
+
+    CHECK(std::is_same_v<decltype(std::declval<const T&>().first()), const int&>);
+    CHECK(std::is_same_v<decltype(std::declval<const T&&>().first()), const int&&>);
+
+    CHECK(std::is_same_v<decltype(std::declval<T&>().second()), int&>);
+    CHECK(std::is_same_v<decltype(std::declval<T&&>().second()), int&&>);
+
+    CHECK(std::is_same_v<decltype(std::declval<const T&>().second()), const int&>);
+    CHECK(std::is_same_v<decltype(std::declval<const T&&>().second()), const int&&>);
+}
+
+TEST_CASE("empty base optimization of compressed_pair", "[compressed_pair][ebo]") {
     ul::compressed_pair<int, int> largest{1, 1};
     ul::compressed_pair<int, empty_cat> middle{1, {}};
     ul::compressed_pair<empty_cat, empty_cat> smallest{{}, {}};


### PR DESCRIPTION
This resolves #5 
- Added ref qualified overloads for get member functions in ul::compressed_pair and ul::compressed_element.
- Added tests which check that the correct overload is chosen when calling said member functions.